### PR TITLE
fix: Unfortunately, MQ Listeners are dependent on the session in the …

### DIFF
--- a/.github/workflows/dockerImage.yml
+++ b/.github/workflows/dockerImage.yml
@@ -66,7 +66,7 @@ jobs:
   push_to_registry:
     strategy:
       matrix:
-        registry: ["docker.pkg.github.com", "ghcr.io"]
+        registry: ["ghcr.io"]
     needs: [test]
     name: Push Docker image to GitHub Packages
     runs-on: ubuntu-latest

--- a/.github/workflows/dockerImage.yml
+++ b/.github/workflows/dockerImage.yml
@@ -9,6 +9,7 @@ on:
     tags:
       - "dockerImage.v.*"
       - "v*"
+  workflow_dispatch:
 
 jobs:
   test:
@@ -32,7 +33,7 @@ jobs:
           architecture: x64
 
       - name: Caching maven dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-maven-dependencies
         with:
@@ -43,7 +44,7 @@ jobs:
         run: mvn -B -Pprod  clean package -DskipTests
       - name: Maven Verify
         run: mvn -B -Pprod clean verify
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: targetfiles
           path: target/*.jar
@@ -74,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Download buildfiles artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: targetfiles
       - name: Get current time

--- a/.github/workflows/dockerImage.yml
+++ b/.github/workflows/dockerImage.yml
@@ -6,6 +6,7 @@ on:
       - 'release'
       - 'staging'
       - 'develop'
+      - '*'
     tags:
       - "dockerImage.v.*"
       - "v*"

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -23,7 +23,7 @@ jobs:
           architecture: x64
 
       - name: Caching maven dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: set env
         run: echo BRANCH=$(echo -n "${GITHUB_REF#refs/heads/}") >> $GITHUB_ENV
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 10

--- a/.github/workflows/securityScan.yml
+++ b/.github/workflows/securityScan.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target/
-!.mvn/wrapper/maven-wrapper.jar
 /node_modules
+log
+/statisticsservice.tar
 
 ### STS ###
 .apt_generated
@@ -24,6 +25,3 @@
 /dist/
 /nbdist/
 /.nb-gradle/
-wrapper
-log
-/statisticsservice.tar

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/mvnw
+++ b/mvnw
@@ -19,207 +19,277 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Maven2 Start Up Batch script
-#
-# Required ENV vars:
-# ------------------
-#   JAVA_HOME - location of a JDK home dir
+# Apache Maven Wrapper startup batch script, version 3.3.4
 #
 # Optional ENV vars
 # -----------------
-#   M2_HOME - location of maven2's installed home dir
-#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
-#     e.g. to debug Maven itself, use
-#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
-#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
 # ----------------------------------------------------------------------------
 
-if [ -z "$MAVEN_SKIP_RC" ] ; then
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
 
-  if [ -f /etc/mavenrc ] ; then
-    . /etc/mavenrc
-  fi
-
-  if [ -f "$HOME/.mavenrc" ] ; then
-    . "$HOME/.mavenrc"
-  fi
-
-fi
-
-# OS specific support.  $var _must_ be set to either true or false.
-cygwin=false;
-darwin=false;
-mingw=false
-case "`uname`" in
-  CYGWIN*) cygwin=true ;;
-  MINGW*) mingw=true;;
-  Darwin*) darwin=true
-    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
-    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
-    if [ -z "$JAVA_HOME" ]; then
-      if [ -x "/usr/libexec/java_home" ]; then
-        export JAVA_HOME="`/usr/libexec/java_home`"
-      else
-        export JAVA_HOME="/Library/Java/Home"
-      fi
-    fi
-    ;;
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
 esac
 
-if [ -z "$JAVA_HOME" ] ; then
-  if [ -r /etc/gentoo-release ] ; then
-    JAVA_HOME=`java-config --jre-home`
-  fi
-fi
-
-if [ -z "$M2_HOME" ] ; then
-  ## resolve links - $0 may be a link to maven's home
-  PRG="$0"
-
-  # need this for relative symlinks
-  while [ -h "$PRG" ] ; do
-    ls=`ls -ld "$PRG"`
-    link=`expr "$ls" : '.*-> \(.*\)$'`
-    if expr "$link" : '/.*' > /dev/null; then
-      PRG="$link"
-    else
-      PRG="`dirname "$PRG"`/$link"
-    fi
-  done
-
-  saveddir=`pwd`
-
-  M2_HOME=`dirname "$PRG"`/..
-
-  # make it fully qualified
-  M2_HOME=`cd "$M2_HOME" && pwd`
-
-  cd "$saveddir"
-  # echo Using m2 at $M2_HOME
-fi
-
-# For Cygwin, ensure paths are in UNIX format before anything is touched
-if $cygwin ; then
-  [ -n "$M2_HOME" ] &&
-    M2_HOME=`cygpath --unix "$M2_HOME"`
-  [ -n "$JAVA_HOME" ] &&
-    JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
-  [ -n "$CLASSPATH" ] &&
-    CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
-fi
-
-# For Migwn, ensure paths are in UNIX format before anything is touched
-if $mingw ; then
-  [ -n "$M2_HOME" ] &&
-    M2_HOME="`(cd "$M2_HOME"; pwd)`"
-  [ -n "$JAVA_HOME" ] &&
-    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
-  # TODO classpath?
-fi
-
-if [ -z "$JAVA_HOME" ]; then
-  javaExecutable="`which javac`"
-  if [ -n "$javaExecutable" ] && ! [ "`expr \"$javaExecutable\" : '\([^ ]*\)'`" = "no" ]; then
-    # readlink(1) is not available as standard on Solaris 10.
-    readLink=`which readlink`
-    if [ ! `expr "$readLink" : '\([^ ]*\)'` = "no" ]; then
-      if $darwin ; then
-        javaHome="`dirname \"$javaExecutable\"`"
-        javaExecutable="`cd \"$javaHome\" && pwd -P`/javac"
-      else
-        javaExecutable="`readlink -f \"$javaExecutable\"`"
-      fi
-      javaHome="`dirname \"$javaExecutable\"`"
-      javaHome=`expr "$javaHome" : '\(.*\)/bin'`
-      JAVA_HOME="$javaHome"
-      export JAVA_HOME
-    fi
-  fi
-fi
-
-if [ -z "$JAVACMD" ] ; then
-  if [ -n "$JAVA_HOME"  ] ; then
-    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
       # IBM's JDK on AIX uses strange locations for the executables
       JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
     else
       JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
     fi
   else
-    JAVACMD="`which java`"
-  fi
-fi
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
 
-if [ ! -x "$JAVACMD" ] ; then
-  echo "Error: JAVA_HOME is not defined correctly." >&2
-  echo "  We cannot execute $JAVACMD" >&2
-  exit 1
-fi
-
-if [ -z "$JAVA_HOME" ] ; then
-  echo "Warning: JAVA_HOME environment variable is not set."
-fi
-
-CLASSWORLDS_LAUNCHER=org.codehaus.plexus.classworlds.launcher.Launcher
-
-# traverses directory structure from process work directory to filesystem root
-# first directory with .mvn subdirectory is considered project base directory
-find_maven_basedir() {
-
-  if [ -z "$1" ]
-  then
-    echo "Path not specified to find_maven_basedir"
-    return 1
-  fi
-
-  basedir="$1"
-  wdir="$1"
-  while [ "$wdir" != '/' ] ; do
-    if [ -d "$wdir"/.mvn ] ; then
-      basedir=$wdir
-      break
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
     fi
-    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
-    if [ -d "${wdir}" ]; then
-      wdir=`cd "$wdir/.."; pwd`
-    fi
-    # end of workaround
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
   done
-  echo "${basedir}"
+  printf %x\\n $h
 }
 
-# concatenates all lines of a file
-concat_lines() {
-  if [ -f "$1" ]; then
-    echo "$(tr -s '\n' ' ' < "$1")"
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
   fi
-}
-
-BASE_DIR=`find_maven_basedir "$(pwd)"`
-if [ -z "$BASE_DIR" ]; then
-  exit 1;
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
 fi
 
-export MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}
-echo $MAVEN_PROJECTBASEDIR
-MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
-
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin; then
-  [ -n "$M2_HOME" ] &&
-    M2_HOME=`cygpath --path --windows "$M2_HOME"`
-  [ -n "$JAVA_HOME" ] &&
-    JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
-  [ -n "$CLASSPATH" ] &&
-    CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
-  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
-    MAVEN_PROJECTBASEDIR=`cygpath --path --windows "$MAVEN_PROJECTBASEDIR"`
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
 fi
 
-WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
 
-exec "$JAVACMD" \
-  $MAVEN_OPTS \
-  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
-  "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
-  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,3 +1,4 @@
+<# : batch portion
 @REM ----------------------------------------------------------------------------
 @REM Licensed to the Apache Software Foundation (ASF) under one
 @REM or more contributor license agreements.  See the NOTICE file
@@ -18,126 +19,171 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Maven2 Start Up Batch script
-@REM
-@REM Required ENV vars:
-@REM JAVA_HOME - location of a JDK home dir
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
 @REM
 @REM Optional ENV vars
-@REM M2_HOME - location of maven2's installed home dir
-@REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
-@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a key stroke before ending
-@REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
-@REM     e.g. to debug Maven itself, use
-@REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
-@REM MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
 @REM ----------------------------------------------------------------------------
 
-@REM Begin all REM lines with '@' in case MAVEN_BATCH_ECHO is 'on'
-@echo off
-@REM enable echoing my setting MAVEN_BATCH_ECHO to 'on'
-@if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
 
-@REM set %HOME% to equivalent of $HOME
-if "%HOME%" == "" (set "HOME=%HOMEDRIVE%%HOMEPATH%")
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
 
-@REM Execute a user defined script before this one
-if not "%MAVEN_SKIP_RC%" == "" goto skipRcPre
-@REM check for pre script, once with legacy .bat ending and once with .cmd ending
-if exist "%HOME%\mavenrc_pre.bat" call "%HOME%\mavenrc_pre.bat"
-if exist "%HOME%\mavenrc_pre.cmd" call "%HOME%\mavenrc_pre.cmd"
-:skipRcPre
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
 
-@setlocal
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
 
-set ERROR_CODE=0
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
 
-@REM To isolate internal variables from possible post scripts, we use another setlocal
-@setlocal
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
 
-@REM ==== START VALIDATION ====
-if not "%JAVA_HOME%" == "" goto OkJHome
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
 
-echo.
-echo Error: JAVA_HOME not found in your environment. >&2
-echo Please set the JAVA_HOME variable in your environment to match the >&2
-echo location of your Java installation. >&2
-echo.
-goto error
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
 
-:OkJHome
-if exist "%JAVA_HOME%\bin\java.exe" goto init
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
 
-echo.
-echo Error: JAVA_HOME is set to an invalid directory. >&2
-echo JAVA_HOME = "%JAVA_HOME%" >&2
-echo Please set the JAVA_HOME variable in your environment to match the >&2
-echo location of your Java installation. >&2
-echo.
-goto error
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
 
-@REM ==== END VALIDATION ====
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
 
-:init
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
 
-@REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
-@REM Fallback to current working directory if not found.
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
 
-set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
-IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
 
-set EXEC_DIR=%CD%
-set WDIR=%EXEC_DIR%
-:findBaseDir
-IF EXIST "%WDIR%"\.mvn goto baseDirFound
-cd ..
-IF "%WDIR%"=="%CD%" goto baseDirNotFound
-set WDIR=%CD%
-goto findBaseDir
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
 
-:baseDirFound
-set MAVEN_PROJECTBASEDIR=%WDIR%
-cd "%EXEC_DIR%"
-goto endDetectBaseDir
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
 
-:baseDirNotFound
-set MAVEN_PROJECTBASEDIR=%EXEC_DIR%
-cd "%EXEC_DIR%"
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
 
-:endDetectBaseDir
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
 
-IF NOT EXIST "%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config" goto endReadAdditionalConfig
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
 
-@setlocal EnableExtensions EnableDelayedExpansion
-for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do set JVM_CONFIG_MAVEN_PROPS=!JVM_CONFIG_MAVEN_PROPS! %%a
-@endlocal & set JVM_CONFIG_MAVEN_PROPS=%JVM_CONFIG_MAVEN_PROPS%
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
 
-:endReadAdditionalConfig
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
 
-SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
 
-set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
-set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
-
-%MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
-if ERRORLEVEL 1 goto error
-goto end
-
-:error
-set ERROR_CODE=1
-
-:end
-@endlocal & set ERROR_CODE=%ERROR_CODE%
-
-if not "%MAVEN_SKIP_RC%" == "" goto skipRcPost
-@REM check for post script, once with legacy .bat ending and once with .cmd ending
-if exist "%HOME%\mavenrc_post.bat" call "%HOME%\mavenrc_post.bat"
-if exist "%HOME%\mavenrc_post.cmd" call "%HOME%\mavenrc_post.cmd"
-:skipRcPost
-
-@REM pause the script if MAVEN_BATCH_PAUSE is set to 'on'
-if "%MAVEN_BATCH_PAUSE%" == "on" pause
-
-if "%MAVEN_TERMINATE_CMD%" == "on" exit %ERROR_CODE%
-
-exit /B %ERROR_CODE%
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <spring-data-mongodb.version>3.3.5</spring-data-mongodb.version>
     <spring-security.version>5.7.5</spring-security.version>
     <ehcache.version>2.10.9.2</ehcache.version>
+    <embedded-mongo.version>2.2.0</embedded-mongo.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -207,18 +207,21 @@
       <scope>test</scope>
       <version>2.0.2</version>
     </dependency>
-
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <!-- EasyRandom -->
     <dependency>
       <groupId>org.jeasy</groupId>
       <artifactId>easy-random-core</artifactId>
       <version>4.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/de/caritas/cob/statisticsservice/api/service/UserStatisticsService.java
+++ b/src/main/java/de/caritas/cob/statisticsservice/api/service/UserStatisticsService.java
@@ -24,7 +24,7 @@ public class UserStatisticsService {
    * @param sessionId the session id
    * @return an {@link SessionStatisticsResultDTO} instance
    */
-  @Cacheable(value = CacheManagerConfig.SESSION_CACHE, key = "#sessionId")
+  @Cacheable(value = CacheManagerConfig.SESSION_CACHE, key = "#sessionId", condition = "#sessionId != null")
   public SessionStatisticsResultDTO retrieveSessionViaSessionId(Long sessionId) {
     return retrieveSession(sessionId, null);
   }
@@ -35,7 +35,7 @@ public class UserStatisticsService {
    * @param rcGroupId the Rocket.Chat group id
    * @return an {@link SessionStatisticsResultDTO} instance
    */
-  @Cacheable(value = CacheManagerConfig.SESSION_CACHE, key = "#rcGroupId")
+  @Cacheable(value = CacheManagerConfig.SESSION_CACHE, key = "#rcGroupId", condition = "#rcGroupId != null")
   public SessionStatisticsResultDTO retrieveSessionViaRcGroupId(String rcGroupId) {
     return retrieveSession(null, rcGroupId);
   }

--- a/src/main/java/de/caritas/cob/statisticsservice/api/statistics/listener/ArchiveSessionListener.java
+++ b/src/main/java/de/caritas/cob/statisticsservice/api/statistics/listener/ArchiveSessionListener.java
@@ -35,6 +35,7 @@ public class ArchiveSessionListener {
     StatisticsEvent statisticsEvent =
         StatisticsEventBuilder.getInstance(
             () -> userStatisticsService.retrieveSessionViaSessionId(eventMessage.getSessionId()))
+            .withSessionId(eventMessage.getSessionId())
             .withEventType(eventMessage.getEventType())
             .withTimestamp(eventMessage.getTimestamp().toInstant())
             .withUserId(eventMessage.getUserId())

--- a/src/main/java/de/caritas/cob/statisticsservice/api/statistics/listener/AssignSessionListener.java
+++ b/src/main/java/de/caritas/cob/statisticsservice/api/statistics/listener/AssignSessionListener.java
@@ -40,6 +40,7 @@ public class AssignSessionListener {
         StatisticsEventBuilder.getInstance(
             () ->
                 userStatisticsService.retrieveSessionViaSessionId(eventMessage.getSessionId()))
+            .withSessionId(eventMessage.getSessionId())
             .withEventType(eventMessage.getEventType())
             .withTimestamp(eventMessage.getTimestamp().toInstant())
             .withUserId(eventMessage.getUserId())

--- a/src/main/java/de/caritas/cob/statisticsservice/api/statistics/listener/RegistrationListener.java
+++ b/src/main/java/de/caritas/cob/statisticsservice/api/statistics/listener/RegistrationListener.java
@@ -1,8 +1,9 @@
 package de.caritas.cob.statisticsservice.api.statistics.listener;
 
+import static java.util.Objects.isNull;
+
 import de.caritas.cob.statisticsservice.api.model.RegistrationStatisticsEventMessage;
 import de.caritas.cob.statisticsservice.api.service.UserStatisticsService;
-import de.caritas.cob.statisticsservice.api.statistics.model.statisticsevent.StatisticsEvent;
 import de.caritas.cob.statisticsservice.api.statistics.model.statisticsevent.StatisticsEventBuilder;
 import de.caritas.cob.statisticsservice.api.statistics.model.statisticsevent.meta.RegistrationMetaData;
 import lombok.NonNull;
@@ -30,12 +31,15 @@ public class RegistrationListener {
       id = "registration-event-listener",
       queues = "#{rabbitMqConfig.QUEUE_NAME_REGISTRATION}",
       containerFactory = "simpleRabbitListenerContainerFactory")
+  @SuppressWarnings({"NullAway", "java:S2583"}) // sessionId can be null despite @NonNull annotation
   public void receiveMessage(RegistrationStatisticsEventMessage eventMessage) {
+    var sessionId = eventMessage.getSessionId();
+    var statisticsEventBuilder = isNull(sessionId)
+        ? StatisticsEventBuilder.getInstance()
+        : StatisticsEventBuilder.getInstance(() -> userStatisticsService.retrieveSessionViaSessionId(sessionId));
 
-    StatisticsEvent statisticsEvent =
-        StatisticsEventBuilder.getInstance(
-            () ->
-                userStatisticsService.retrieveSessionViaSessionId(eventMessage.getSessionId()))
+    var statisticsEvent = statisticsEventBuilder
+            .withSessionId(eventMessage.getSessionId())
             .withEventType(eventMessage.getEventType())
             .withTimestamp(eventMessage.getTimestamp().toInstant())
             .withUserId(eventMessage.getUserId())

--- a/src/main/java/de/caritas/cob/statisticsservice/api/statistics/listener/StartVideoCallListener.java
+++ b/src/main/java/de/caritas/cob/statisticsservice/api/statistics/listener/StartVideoCallListener.java
@@ -32,6 +32,7 @@ public class StartVideoCallListener {
       id = "start-video-call-event-listener",
       queues = "#{rabbitMqConfig.QUEUE_NAME_START_VIDEO_CALL}",
       containerFactory = "simpleRabbitListenerContainerFactory")
+  @SuppressWarnings({"NullAway", "java:S2583"}) // sessionId can be null despite @NonNull annotation
   public void receiveMessage(StartVideoCallStatisticsEventMessage eventMessage) {
     var sessionId = eventMessage.getSessionId();
     var statisticsEventBuilder = isNull(sessionId)
@@ -39,6 +40,7 @@ public class StartVideoCallListener {
             : StatisticsEventBuilder.getInstance(() -> userStatisticsService.retrieveSessionViaSessionId(sessionId));
 
     var statisticsEvent = statisticsEventBuilder
+            .withSessionId(eventMessage.getSessionId())
             .withEventType(eventMessage.getEventType())
             .withTimestamp(eventMessage.getTimestamp().truncatedTo(ChronoUnit.SECONDS).toInstant())
             .withUserId(eventMessage.getUserId())

--- a/src/main/java/de/caritas/cob/statisticsservice/api/statistics/model/statisticsevent/StatisticsEventBuilder.java
+++ b/src/main/java/de/caritas/cob/statisticsservice/api/statistics/model/statisticsevent/StatisticsEventBuilder.java
@@ -6,16 +6,20 @@ import de.caritas.cob.statisticsservice.userstatisticsservice.generated.web.mode
 
 import java.time.Instant;
 import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 
 /** Builder for a {@link StatisticsEvent} instance. */
+@Slf4j
 public class StatisticsEventBuilder {
 
   private final Supplier<SessionStatisticsResultDTO> sessionSupplier;
   private EventType eventType;
   private Instant timestamp;
+  private Long sessionId;
   private String userId;
   private UserRole userRole;
   private Object metaData;
@@ -42,6 +46,17 @@ public class StatisticsEventBuilder {
 
   public static StatisticsEventBuilder getInstance() {
     return new StatisticsEventBuilder();
+  }
+
+  /**
+   * Sets the session id.
+   *
+   * @param sessionId the session id of the event
+   * @return the current {@link StatisticsEventBuilder}
+   */
+  public StatisticsEventBuilder withSessionId(Long sessionId) {
+    this.sessionId = sessionId;
+    return this;
   }
 
   /**
@@ -115,18 +130,11 @@ public class StatisticsEventBuilder {
             .user(buildUser())
             .metaData(metaData);
 
-    if (isNull(sessionSupplier)) {
-      if (eventType != EventType.START_VIDEO_CALL) {
-        throw new IllegalArgumentException("Mandatory session of event type " + eventType + " missing.");
-      }
-    } else {
-      var session = sessionSupplier.get();
-      requireNonNull(session.getId());
-      eventBuilder
-              .sessionId(session.getId())
-              .consultingType(buildConsultingType(session))
-              .agency(buildAgency(session));
+    // We set the sessionId here. Nevertheless, we try to load the session to read Agency and ConsultingType from the session.
+    if (nonNull(sessionId)) {
+      eventBuilder.sessionId(sessionId);
     }
+    tryLoadSessionData(eventBuilder);
 
     return eventBuilder.build();
   }
@@ -160,4 +168,45 @@ public class StatisticsEventBuilder {
         .id(this.userId)
         .build();
   }
+
+  /**
+   * Attempts to load session data from the supplier. If loading fails (e.g., session not found),
+   * logs a warning and continues without session data. This allows processing of events even when
+   * sessions have been deleted.
+   */
+  private void tryLoadSessionData(StatisticsEvent.StatisticsEventBuilder eventBuilder) {
+    if (shouldSkipSessionLoading()) {
+      return;
+    }
+
+    try {
+      assert sessionSupplier != null;
+      var session = sessionSupplier.get();
+
+      if (isNull(session)) {
+        log.warn("Session supplier returned null for event type {}. "
+            + "Continuing without session data.", eventType);
+        return;
+      }
+
+      eventBuilder
+          .sessionId(session.getId())
+          .consultingType(buildConsultingType(session))
+          .agency(buildAgency(session));
+
+    } catch (Exception e) {
+      // Session lookup failed (most likely 404 - session was deleted)
+      // This is expected for old events where sessions have been cleaned up
+      log.info("Failed to load session data for event type {}. "
+              + "Continuing without session data. Reason: {} - {}",
+          eventType,
+          e.getClass().getSimpleName(),
+          e.getMessage());
+    }
+  }
+
+  private boolean shouldSkipSessionLoading() {
+    return isNull(sessionSupplier);
+  }
+
 }

--- a/src/test/java/de/caritas/cob/statisticsservice/api/service/UserStatisticsServiceTest.java
+++ b/src/test/java/de/caritas/cob/statisticsservice/api/service/UserStatisticsServiceTest.java
@@ -1,6 +1,5 @@
 package de.caritas.cob.statisticsservice.api.service;
 
-
 import static de.caritas.cob.statisticsservice.api.testhelper.TestConstants.RC_GROUP_ID;
 import static de.caritas.cob.statisticsservice.api.testhelper.TestConstants.SESSION_ID;
 import static org.mockito.Mockito.times;
@@ -9,6 +8,8 @@ import static org.mockito.Mockito.when;
 
 import de.caritas.cob.statisticsservice.api.service.securityheader.SecurityHeaderSupplier;
 import de.caritas.cob.statisticsservice.api.service.securityheader.TenantHeaderSupplier;
+import de.caritas.cob.statisticsservice.config.apiclient.UserStatisticsApiControllerFactory;
+import de.caritas.cob.statisticsservice.userstatisticsservice.generated.ApiClient;
 import de.caritas.cob.statisticsservice.userstatisticsservice.generated.web.UserStatisticsControllerApi;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,31 +23,47 @@ public class UserStatisticsServiceTest {
 
   @InjectMocks
   UserStatisticsService userStatisticsService;
+
+  @Mock
+  UserStatisticsApiControllerFactory userStatisticsApiControllerFactory;
+
   @Mock
   UserStatisticsControllerApi userStatisticsControllerApi;
+
+  @Mock
+  ApiClient apiClient;
+
   @Mock
   SecurityHeaderSupplier securityHeaderSupplier;
+
   @Mock
   TenantHeaderSupplier tenantHeaderSupplier;
 
   @Test
   public void retrieveSessionViaRcGroupId_Should_RetrieveSessionViaUserStatisticsControllerApi() {
-
     var headers = new HttpHeaders();
     when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(headers);
+    when(userStatisticsApiControllerFactory.createControllerApi()).thenReturn(userStatisticsControllerApi);
+    when(userStatisticsControllerApi.getApiClient()).thenReturn(apiClient);
+
     userStatisticsService.retrieveSessionViaRcGroupId(RC_GROUP_ID);
+
+    verify(userStatisticsApiControllerFactory, times(1)).createControllerApi();
     verify(userStatisticsControllerApi, times(1)).getSession(null, RC_GROUP_ID);
     verify(tenantHeaderSupplier).addTechnicalTenantHeaderIfMultitenancyEnabled(headers);
   }
 
   @Test
   public void retrieveSessionViaSessionId_Should_RetrieveSessionViaUserStatisticsControllerApi() {
-
     var headers = new HttpHeaders();
     when(securityHeaderSupplier.getCsrfHttpHeaders()).thenReturn(headers);
+    when(userStatisticsApiControllerFactory.createControllerApi()).thenReturn(userStatisticsControllerApi);
+    when(userStatisticsControllerApi.getApiClient()).thenReturn(apiClient);
+
     userStatisticsService.retrieveSessionViaSessionId(SESSION_ID);
+
+    verify(userStatisticsApiControllerFactory, times(1)).createControllerApi();
     verify(userStatisticsControllerApi, times(1)).getSession(SESSION_ID, null);
     verify(tenantHeaderSupplier, times(1)).addTechnicalTenantHeaderIfMultitenancyEnabled(headers);
   }
-
 }

--- a/src/test/java/de/caritas/cob/statisticsservice/api/statistics/listener/ArchiveSessionListenerTest.java
+++ b/src/test/java/de/caritas/cob/statisticsservice/api/statistics/listener/ArchiveSessionListenerTest.java
@@ -8,6 +8,7 @@ import static de.caritas.cob.statisticsservice.api.testhelper.TestConstants.SESS
 import static de.caritas.cob.statisticsservice.api.testhelper.TestConstants.TENANT_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -61,6 +62,32 @@ public class ArchiveSessionListenerTest {
     assertThat(statisticsEvent.getSessionId(), is(SESSION_ID));
     assertThat(statisticsEvent.getConsultingType().getId(), is(CONSULTING_TYPE_ID));
     assertThat(statisticsEvent.getAgency().getId(), is(AGENCY_ID));
+    assertThat(statisticsEvent.getTimestamp(), is(timestamp.toInstant()));
+    assertThat(statisticsEvent.getUser().getId(), is(CONSULTANT_ID));
+    assertThat(statisticsEvent.getUser().getUserRole(), is(UserRole.CONSULTANT));
+    assertThat(statisticsEvent.getMetaData(), is(buildMetaData()));
+  }
+
+  @Test
+  public void receiveMessage_Should_saveEventWithSessionId_WhenSessionDataNotAvailable() {
+    // given
+    when(userStatisticsService.retrieveSessionViaSessionId(SESSION_ID))
+        .thenThrow(new RuntimeException("Session deleted"));
+
+    OffsetDateTime timestamp = OffsetDateTime.now();
+    ArchiveSessionStatisticsEventMessage archiveSessionStatisticsEventMessage = buildEventMessage(timestamp);
+
+    // when
+    archiveSessionListener.receiveMessage(archiveSessionStatisticsEventMessage);
+
+    // then
+    verify(mongoTemplate).insert(statisticsEventCaptor.capture());
+
+    StatisticsEvent statisticsEvent = statisticsEventCaptor.getValue();
+    assertThat(statisticsEvent.getEventType(), is(EventType.ARCHIVE_SESSION));
+    assertThat(statisticsEvent.getSessionId(), is(SESSION_ID));
+    assertThat(statisticsEvent.getConsultingType(), nullValue());
+    assertThat(statisticsEvent.getAgency(), nullValue());
     assertThat(statisticsEvent.getTimestamp(), is(timestamp.toInstant()));
     assertThat(statisticsEvent.getUser().getId(), is(CONSULTANT_ID));
     assertThat(statisticsEvent.getUser().getUserRole(), is(UserRole.CONSULTANT));

--- a/src/test/java/de/caritas/cob/statisticsservice/api/statistics/listener/AssignSessionListenerTest.java
+++ b/src/test/java/de/caritas/cob/statisticsservice/api/statistics/listener/AssignSessionListenerTest.java
@@ -28,6 +28,7 @@ import static de.caritas.cob.statisticsservice.api.testhelper.TestConstants.SESS
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -74,6 +75,39 @@ public class AssignSessionListenerTest {
     assertThat(metaMap.get("requestUri"), is(assignSessionStatisticsEventMessage.getRequestUri()));
     assertThat(metaMap.get("requestUserId"), is(assignSessionStatisticsEventMessage.getRequestUserId()));
     assertThat(metaMap.containsKey(RandomStringUtils.randomAlphanumeric(64)), is(false));
+  }
+
+  @Test
+  public void receiveMessage_Should_saveEventWithSessionId_WhenSessionDataNotAvailable() {
+    // given
+    when(userStatisticsService.retrieveSessionViaSessionId(SESSION_ID))
+        .thenThrow(new RuntimeException("Session not found"));
+
+    AssignSessionStatisticsEventMessage assignSessionStatisticsEventMessage = buildEventMessage(true);
+
+    // when
+    assignSessionListener.receiveMessage(assignSessionStatisticsEventMessage);
+
+    // then
+    verify(mongoTemplate).insert(statisticsEventCaptor.capture());
+
+    StatisticsEvent statisticsEvent = statisticsEventCaptor.getValue();
+    assertThat(statisticsEvent.getEventType(), is(assignSessionStatisticsEventMessage.getEventType()));
+    assertThat(statisticsEvent.getSessionId(), is(SESSION_ID));
+    assertThat(statisticsEvent.getConsultingType(), nullValue());
+    assertThat(statisticsEvent.getAgency(), nullValue());
+    assertThat(statisticsEvent.getTimestamp(), is(assignSessionStatisticsEventMessage.getTimestamp().toInstant()));
+    assertThat(statisticsEvent.getUser().getId(), is(assignSessionStatisticsEventMessage.getUserId()));
+    assertThat(statisticsEvent.getUser().getUserRole(), is(UserRole.CONSULTANT));
+
+    var metaData = statisticsEvent.getMetaData();
+    assertThat(metaData, isA(Map.class));
+
+    @SuppressWarnings("unchecked")
+    var metaMap = (Map<String, String>) metaData;
+    assertThat(metaMap.get("requestReferer"), is(assignSessionStatisticsEventMessage.getRequestReferer()));
+    assertThat(metaMap.get("requestUri"), is(assignSessionStatisticsEventMessage.getRequestUri()));
+    assertThat(metaMap.get("requestUserId"), is(assignSessionStatisticsEventMessage.getRequestUserId()));
   }
 
   @Test

--- a/src/test/java/de/caritas/cob/statisticsservice/api/statistics/listener/CreateMessageListenerTest.java
+++ b/src/test/java/de/caritas/cob/statisticsservice/api/statistics/listener/CreateMessageListenerTest.java
@@ -7,6 +7,7 @@ import static de.caritas.cob.statisticsservice.api.testhelper.TestConstants.RC_G
 import static de.caritas.cob.statisticsservice.api.testhelper.TestConstants.SESSION_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -58,6 +59,31 @@ public class CreateMessageListenerTest {
     assertThat(statisticsEvent.getSessionId(), is(sessionStatisticsResultDTO.getId()));
     assertThat(statisticsEvent.getConsultingType().getId(), is(sessionStatisticsResultDTO.getConsultingType()));
     assertThat(statisticsEvent.getAgency().getId(), is(sessionStatisticsResultDTO.getAgencyId()));
+    assertThat(statisticsEvent.getTimestamp(), is(createMessageStatisticsEventMessage.getTimestamp().toInstant()));
+    assertThat(statisticsEvent.getUser().getId(), is(createMessageStatisticsEventMessage.getUserId()));
+    assertThat(statisticsEvent.getUser().getUserRole(), is(UserRole.CONSULTANT));
+    assertThat(statisticsEvent.getMetaData(), is(buildMetaData(createMessageStatisticsEventMessage)));
+  }
+
+  @Test
+  public void receiveMessage_Should_saveEventWithoutSessionData_WhenSessionDataNotAvailable() {
+    // given
+    when(userStatisticsService.retrieveSessionViaRcGroupId(RC_GROUP_ID))
+        .thenThrow(new RuntimeException("Session not found"));
+
+    CreateMessageStatisticsEventMessage createMessageStatisticsEventMessage = buildEventMessage();
+
+    // when
+    createMessageListener.receiveMessage(createMessageStatisticsEventMessage);
+
+    // then
+    verify(mongoTemplate).insert(statisticsEventCaptor.capture());
+
+    StatisticsEvent statisticsEvent = statisticsEventCaptor.getValue();
+    assertThat(statisticsEvent.getEventType(), is(createMessageStatisticsEventMessage.getEventType()));
+    assertThat(statisticsEvent.getSessionId(), nullValue());
+    assertThat(statisticsEvent.getConsultingType(), nullValue());
+    assertThat(statisticsEvent.getAgency(), nullValue());
     assertThat(statisticsEvent.getTimestamp(), is(createMessageStatisticsEventMessage.getTimestamp().toInstant()));
     assertThat(statisticsEvent.getUser().getId(), is(createMessageStatisticsEventMessage.getUserId()));
     assertThat(statisticsEvent.getUser().getUserRole(), is(UserRole.CONSULTANT));

--- a/src/test/java/de/caritas/cob/statisticsservice/api/statistics/listener/RegistrationListenerTest.java
+++ b/src/test/java/de/caritas/cob/statisticsservice/api/statistics/listener/RegistrationListenerTest.java
@@ -8,6 +8,7 @@ import static de.caritas.cob.statisticsservice.api.testhelper.TestConstants.SESS
 import static de.caritas.cob.statisticsservice.api.testhelper.TestConstants.TENANT_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,6 +73,61 @@ public class RegistrationListenerTest {
         is(buildMetaData(registrationStatisticsEventMessage)));
   }
 
+  @Test
+  public void registration_Should_saveEventWithSessionId_WhenSessionDataNotAvailable() {
+    // given
+    when(userStatisticsService.retrieveSessionViaSessionId(SESSION_ID))
+        .thenThrow(new RuntimeException("Session deleted"));
+
+    RegistrationStatisticsEventMessage registrationStatisticsEventMessage = buildEventMessage();
+
+    // when
+    registrationListener.receiveMessage(registrationStatisticsEventMessage);
+
+    // then
+    verify(mongoTemplate).insert(statisticsEventCaptor.capture());
+
+    StatisticsEvent statisticsEvent = statisticsEventCaptor.getValue();
+    assertThat(statisticsEvent.getEventType(),
+        is(registrationStatisticsEventMessage.getEventType()));
+    assertThat(statisticsEvent.getSessionId(), is(SESSION_ID));
+    assertThat(statisticsEvent.getConsultingType(), nullValue());
+    assertThat(statisticsEvent.getAgency(), nullValue());
+    assertThat(statisticsEvent.getTimestamp(),
+        is(registrationStatisticsEventMessage.getTimestamp().toInstant()));
+    assertThat(statisticsEvent.getUser().getId(),
+        is(registrationStatisticsEventMessage.getUserId()));
+    assertThat(statisticsEvent.getUser().getUserRole(), is(UserRole.ASKER));
+    assertThat(statisticsEvent.getMetaData(),
+        is(buildMetaData(registrationStatisticsEventMessage)));
+  }
+
+  @Test
+  public void registration_Should_saveEventWithoutSession_WhenSessionIdIsNull() {
+    // given
+    RegistrationStatisticsEventMessage registrationStatisticsEventMessage = buildEventMessageWithoutSession();
+
+    // when
+    registrationListener.receiveMessage(registrationStatisticsEventMessage);
+
+    // then
+    verify(mongoTemplate).insert(statisticsEventCaptor.capture());
+
+    StatisticsEvent statisticsEvent = statisticsEventCaptor.getValue();
+    assertThat(statisticsEvent.getEventType(),
+        is(registrationStatisticsEventMessage.getEventType()));
+    assertThat(statisticsEvent.getSessionId(), nullValue());
+    assertThat(statisticsEvent.getConsultingType(), nullValue());
+    assertThat(statisticsEvent.getAgency(), nullValue());
+    assertThat(statisticsEvent.getTimestamp(),
+        is(registrationStatisticsEventMessage.getTimestamp().toInstant()));
+    assertThat(statisticsEvent.getUser().getId(),
+        is(registrationStatisticsEventMessage.getUserId()));
+    assertThat(statisticsEvent.getUser().getUserRole(), is(UserRole.ASKER));
+    assertThat(statisticsEvent.getMetaData(),
+        is(buildMetaData(registrationStatisticsEventMessage)));
+  }
+
   private SessionStatisticsResultDTO buildResultDto() {
     return new SessionStatisticsResultDTO()
         .id(SESSION_ID)
@@ -97,6 +153,22 @@ public class RegistrationListenerTest {
         .postalCode("99999")
         .timestamp(OffsetDateTime.now());
 
+  }
+
+  private RegistrationStatisticsEventMessage buildEventMessageWithoutSession() {
+    return new RegistrationStatisticsEventMessage()
+        .tenantId(TENANT_ID)
+        .eventType(EventType.REGISTRATION)
+        .userId(ASKER_ID)
+        .userRole(UserRole.ASKER)
+        .registrationDate("2022-08-15T21:11:29")
+        .age(25)
+        .gender("FEMALE")
+        .counsellingRelation("SELF_COUNSELLING")
+        .topicsInternalAttributes(List.of("angeho01", "angeho13"))
+        .mainTopicInternalAttribute("angeho01")
+        .postalCode("99999")
+        .timestamp(OffsetDateTime.now());
   }
 
   private RegistrationMetaData buildMetaData(RegistrationStatisticsEventMessage eventMessage) {

--- a/src/test/java/de/caritas/cob/statisticsservice/api/statistics/listener/StartVideoCallListenerTest.java
+++ b/src/test/java/de/caritas/cob/statisticsservice/api/statistics/listener/StartVideoCallListenerTest.java
@@ -81,6 +81,34 @@ public class StartVideoCallListenerTest {
   }
 
   @Test
+  public void receiveMessage_Should_saveEventWithSessionId_WhenSessionDataNotAvailable() {
+    // given
+    when(userStatisticsService.retrieveSessionViaSessionId(SESSION_ID))
+        .thenThrow(new RuntimeException("Session deleted"));
+
+    StartVideoCallStatisticsEventMessage startVideoCallStatisticsEventMessage = buildEventMessageWithSession();
+
+    // when
+    startVideoCallListener.receiveMessage(startVideoCallStatisticsEventMessage);
+
+    // then
+    verify(mongoTemplate).insert(statisticsEventCaptor.capture());
+
+    StatisticsEvent statisticsEvent = statisticsEventCaptor.getValue();
+    assertThat(statisticsEvent.getEventType(), is(startVideoCallStatisticsEventMessage.getEventType()));
+    assertThat(statisticsEvent.getSessionId(), is(SESSION_ID));
+    assertThat(statisticsEvent.getConsultingType(), is(nullValue()));
+    assertThat(statisticsEvent.getAgency(), is(nullValue()));
+    assertThat(
+        statisticsEvent.getTimestamp(),
+        is(startVideoCallStatisticsEventMessage.getTimestamp().truncatedTo(ChronoUnit.SECONDS).toInstant())
+    );
+    assertThat(statisticsEvent.getUser().getId(), is(startVideoCallStatisticsEventMessage.getUserId()));
+    assertThat(statisticsEvent.getUser().getUserRole(), is(UserRole.CONSULTANT));
+    assertThat(statisticsEvent.getMetaData(), is(buildMetaData(startVideoCallStatisticsEventMessage)));
+  }
+
+  @Test
   public void receiveMessage_Should_saveEventWithoutSessionToMongoDb() {
     when(userStatisticsService.retrieveSessionViaSessionId(SESSION_ID))
             .thenReturn(buildResultDto());

--- a/src/test/java/de/caritas/cob/statisticsservice/api/statistics/model/StatisticsEventBuilderTest.java
+++ b/src/test/java/de/caritas/cob/statisticsservice/api/statistics/model/StatisticsEventBuilderTest.java
@@ -84,26 +84,6 @@ public class StatisticsEventBuilderTest {
         .build();
   }
 
-  @Test(expected = NullPointerException.class)
-  public void build_Should_ThrowNullPointerException_WhenRetrievedSessionHasNoId() {
-
-    SessionStatisticsResultDTO session = buildSessionStatisticsResultDto();
-    session.id(null);
-
-    when(userStatisticsService.retrieveSessionViaSessionId(SESSION_ID))
-        .thenReturn(session);
-
-    StatisticsEventBuilder builder =
-        StatisticsEventBuilder.getInstance(
-            () -> userStatisticsService.retrieveSessionViaSessionId(SESSION_ID));
-    builder
-        .withEventType(EventType.ASSIGN_SESSION)
-        .withTimestamp(Instant.now())
-        .withUserId(CONSULTANT_ID)
-        .withUserRole(UserRole.CONSULTANT)
-        .build();
-  }
-
   @Test
   public void build_Should_Build_ValidStatisticEventsModel() {
 
@@ -160,40 +140,93 @@ public class StatisticsEventBuilderTest {
   }
 
   @Test
-  public void buildShouldNotRequestSessionFromUserServiceOnStartVideoCallEvent() {
-    Instant now = Instant.now();
+  public void build_Should_BuildWithoutSessionData_WhenNoSupplierProvided() {
+    // given
+    Instant timestamp = Instant.now();
     Object metaData = buildMetaData();
 
-    var result = StatisticsEventBuilder.getInstance()
+    // when
+    StatisticsEvent result = StatisticsEventBuilder.getInstance()
             .withEventType(EventType.START_VIDEO_CALL)
-            .withTimestamp(now)
+            .withTimestamp(timestamp)
             .withUserId(CONSULTANT_ID)
             .withUserRole(UserRole.CONSULTANT)
             .withMetaData(metaData)
             .build();
 
+    // then
     assertThat(result.getEventType(), is(EventType.START_VIDEO_CALL));
-    assertThat(result.getTimestamp(), is(now));
+    assertThat(result.getTimestamp(), is(timestamp));
     assertThat(result.getMetaData(), notNullValue());
     assertThat(result.getMetaData(), is(metaData));
     assertThat(result.getUser(), notNullValue());
     assertThat(result.getUser().getId(), is(CONSULTANT_ID));
     assertThat(result.getUser().getUserRole(), is(UserRole.CONSULTANT));
+    assertThat(result.getSessionId(), nullValue());
     assertThat(result.getAgency(), nullValue());
     assertThat(result.getConsultingType(), nullValue());
 
     verifyNoInteractions(userStatisticsService);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void buildShouldIllegalArgExceptionOnMissingSessionAndNotStartVideoCallEvent() {
-    StatisticsEventBuilder.getInstance()
-            .withEventType(EventType.ASSIGN_SESSION)
-            .withTimestamp(Instant.now())
-            .withUserId(CONSULTANT_ID)
-            .withUserRole(UserRole.CONSULTANT)
-            .withMetaData(new Object())
-            .build();
+  @Test
+  public void build_Should_SetSessionIdEvenWhenSessionDataLoadingFails() {
+    // given
+    when(userStatisticsService.retrieveSessionViaSessionId(SESSION_ID))
+        .thenThrow(new RuntimeException("Session not found"));
+
+    Instant timestamp = Instant.now();
+    Object metaData = buildMetaData();
+
+    // when
+    StatisticsEvent result = StatisticsEventBuilder.getInstance(
+        () -> userStatisticsService.retrieveSessionViaSessionId(SESSION_ID))
+        .withSessionId(SESSION_ID)
+        .withEventType(EventType.ARCHIVE_SESSION)
+        .withTimestamp(timestamp)
+        .withUserId(CONSULTANT_ID)
+        .withUserRole(UserRole.CONSULTANT)
+        .withMetaData(metaData)
+        .build();
+
+    // then
+    assertThat(result.getSessionId(), is(SESSION_ID));
+    assertThat(result.getEventType(), is(EventType.ARCHIVE_SESSION));
+    assertThat(result.getTimestamp(), is(timestamp));
+    assertThat(result.getUser().getId(), is(CONSULTANT_ID));
+    assertThat(result.getUser().getUserRole(), is(UserRole.CONSULTANT));
+    assertThat(result.getMetaData(), is(metaData));
+    assertThat(result.getAgency(), nullValue());
+    assertThat(result.getConsultingType(), nullValue());
+  }
+
+  @Test
+  public void build_Should_SetSessionIdWithNullSupplierButExplicitSessionId() {
+    // given
+    Instant timestamp = Instant.now();
+    Object metaData = buildMetaData();
+
+    // when
+    StatisticsEvent result = StatisticsEventBuilder.getInstance()
+        .withSessionId(SESSION_ID)
+        .withEventType(EventType.START_VIDEO_CALL)
+        .withTimestamp(timestamp)
+        .withUserId(CONSULTANT_ID)
+        .withUserRole(UserRole.CONSULTANT)
+        .withMetaData(metaData)
+        .build();
+
+    // then
+    assertThat(result.getSessionId(), is(SESSION_ID));
+    assertThat(result.getEventType(), is(EventType.START_VIDEO_CALL));
+    assertThat(result.getTimestamp(), is(timestamp));
+    assertThat(result.getUser().getId(), is(CONSULTANT_ID));
+    assertThat(result.getUser().getUserRole(), is(UserRole.CONSULTANT));
+    assertThat(result.getMetaData(), is(metaData));
+    assertThat(result.getAgency(), nullValue());
+    assertThat(result.getConsultingType(), nullValue());
+
+    verifyNoInteractions(userStatisticsService);
   }
 
   private SessionStatisticsResultDTO buildSessionStatisticsResultDto() {


### PR DESCRIPTION
…database. The session is loaded and enriched with Agency Id and ConsultingType. However, there were cases where MQ events were processed late, the session had already been deleted, and the event was not processed (dead letter).

The implementation is fundamentally poorly designed, even if the tests run.

As a “quick” fix, we are now making the loading of the session fault-tolerant. If the session is missing, the event is still processed, the SessionId from the event is used, and the Agency Id and ConsultingType data are not saved.

The sessionSupplier in StatisticsEventBuilder can be null. In this case the sessionId in the RegistrationStatisticsEventMessage can be null (it's related to GroupChatV1).

Anyway the business logic for Start_Video_Call does not really belong in StatisticsEventBuilder, so we are making it more generic.

Also Fixed:
- Maven Wrapper was initialized incorrectly.
- With mvn test, only the new junit5 tests were executed, NOT the old juni4 tests. To fix this, “org.junit.vintage” was added so that both test types are actually executed.
- Fix faulty tests because they never run :/
- Update outdated Actions (cache, checkout and upload/download)

Refs: CARITAS-854, DIAKONIE-620

Fixes #

## Proposed Changes

  -
  -
  -
